### PR TITLE
Update to julia 1

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1.7'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            using Documenter: doctest
+            using PowerAnalysis
+            doctest(PowerAnalysis)'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,14 @@
+name = "PowerAnalysis"
+uuid = "5a0c7668-094f-4ec7-a1f1-c12ec26c441a"
+authors = ["John Myles White"]
+
+[deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+
+[compat]
+Distributions = "0.24"
+HypothesisTests = "0.10"
+julia = "1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -11,4 +11,6 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 [compat]
 Distributions = "0.24"
 HypothesisTests = "0.10"
+Roots = "1"
+QuadGK = "2"
 julia = "1.1"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 0.3-
-Distributions
-HypothesisTests
-Roots
-Docile

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PowerAnalysis = "c1344dcd-d594-46fa-aaa3-386577f687ad"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,21 @@
+using PowerAnalysis
+using Documenter
+
+makedocs(;
+    modules=[PowerAnalysis],
+    authors="John Myles White",
+    repo="https://github.com/johnmyleswhite/PowerAnalysis.jl/blob/{commit}{path}#L{line}",
+    sitename="PowerAnalysis.jl",
+    format=Documenter.HTML(;
+        prettyurls=get(ENV, "CI", "false") == "true",
+        canonical="https://johnmyleswhite.github.io/PowerAnalysis.jl",
+        assets=String[],
+    ),
+    pages=[
+        "Home" => "index.md",
+    ],
+)
+
+deploydocs(;
+    repo="github.com/johnmyleswhite/PowerAnalysis.jl",
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,12 @@
+```@meta
+CurrentModule = PowerAnalysis
+```
+
+# PowerAnalysis
+
+```@index
+```
+
+```@autodocs
+Modules = [PowerAnalysis]
+```

--- a/src/PowerAnalysis.jl
+++ b/src/PowerAnalysis.jl
@@ -1,13 +1,14 @@
 module PowerAnalysis
-    using Docile
-    @docstrings
-
-    using Distributions, HypothesisTests, Roots
+    using Distributions
+    using HypothesisTests
+    using Roots
 
     # TODO: Move z-tests into HypothesisTests
-    abstract OneSampleZTest
-    abstract EqualVarianceZTest
-    export OneSampleZTest, EqualVarianceZTest
+    abstract type OneSampleZTest end
+    abstract type EqualVarianceZTest end
+    
+    export OneSampleZTest
+           EqualVarianceZTest
 
     export
         power,

--- a/src/PowerAnalysis.jl
+++ b/src/PowerAnalysis.jl
@@ -2,6 +2,7 @@ module PowerAnalysis
     using Distributions
     using HypothesisTests
     using Roots
+    using QuadGK
 
     # TODO: Move z-tests into HypothesisTests
     abstract type OneSampleZTest end

--- a/src/PowerAnalysis.jl
+++ b/src/PowerAnalysis.jl
@@ -4,13 +4,6 @@ module PowerAnalysis
     using Roots
     using QuadGK
 
-    # TODO: Move z-tests into HypothesisTests
-    abstract type OneSampleZTest end
-    abstract type EqualVarianceZTest end
-    
-    export OneSampleZTest
-           EqualVarianceZTest
-
     export
         power,
         effect_size,

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -211,7 +211,7 @@ function exaggeration_factor(
         p_significant = ccdf(alt, c_r)
         f0(t) = (t / t_r) * (pdf(alt, t) / p_significant)
         i_r = cquantile(alt, bounds)
-        e_r = quadgk(f0, c_r, i_r, reltol = tol)[1]
+        e_r = gauss(f0, c_r, i_r, rtol = tol)[1]
         return e_r
     else
         c_l, c_r = quantile(null, α / 2), cquantile(null, α / 2)
@@ -220,8 +220,8 @@ function exaggeration_factor(
         f1(t) = (t / t_l) * (pdf(alt, t) / p_significant)
         f2(t) = (t / t_r) * (pdf(alt, t) / p_significant)
         i_l, i_r = quantile(alt, bounds), cquantile(alt, bounds)
-        e_l = quadgk(f1, i_l, c_l, reltol = tol)[1]
-        e_r = quadgk(f2, c_r, i_r, reltol = tol)[1]
+        e_l = gauss(f1, i_l, c_l, rtol = tol)[1]
+        e_r = gauss(f2, c_r, i_r, rtol = tol)[1]
         return e_l + e_r
     end
 end

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -1,15 +1,15 @@
-@doc """
+"""
 Compute the power of a test without checking arguments. Useful inside of loops
 that need to evaluate the power of many proposed designs.
-""" ->
-function analytic_power{T}(
+"""
+function analytic_power(
     ::Type{T},
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     α::Real,
     one_sided::Bool,
-)
+) where {T}
     null, alt = hypotheses(T, ns, δ, σs)
     if one_sided
         c_r = cquantile(null, α)
@@ -21,7 +21,7 @@ function analytic_power{T}(
     end
 end
 
-@doc """
+"""
 Compute the power of a test. Users must specify:
 
 * `ns`: Per-group sample size(s)
@@ -29,40 +29,40 @@ Compute the power of a test. Users must specify:
 * `σs`: Per-group standard deviations
 * `α`: Significance level (defaults to 0.05)
 * `one_sided`: Is the test one-sided? (defaults to false)
-""" ->
-function power{T}(
+"""
+function power(
     ::Type{T},
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     α::Real = 0.05,
     one_sided::Bool = false,
-)
+) where {T}
     check_args(ns, δ, σs, 0.8, α)
     return analytic_power(T, ns, δ, σs, α, one_sided)
 end
 
-@doc """
+"""
 Compute the smallest effect size measurable using a test. Users must specify:
 
 * `ns`: Per-group sample size(s)
 * `p`: Desired power
 * `α`: Significance level (defaults to 0.05)
 * `one_sided`: Is the test one-sided? (defaults to false)
-""" ->
-function effect_size{T}(
+"""
+function effect_size(
     ::Type{T},
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     p::Real,
     α::Real = 0.05,
     one_sided::Bool = false,
-)
+) where {T}
     check_args(ns, 1.0, 1.0, p, α)
     gap(δ::Real) = analytic_power(T, ns, δ, 1.0, α, one_sided) - p
     return fzero(gap, 1e-8, 100.0)
 end
 
-@doc """
+"""
 Compute the smallest sample size that allows using a test to measure a
 specified effect. Users must specify:
 
@@ -71,21 +71,21 @@ specified effect. Users must specify:
 * `p`: Desired power
 * `α`: Significance level (defaults to 0.05)
 * `one_sided`: Is the test one-sided? (defaults to false)
-""" ->
-function sample_size{T}(
+"""
+function sample_size(
     ::Type{T},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     p::Real,
     α::Real = 0.05,
     one_sided::Bool = false,
-)
+) where {T}
     check_args(2, δ, σs, p, α)
     gap(n::Real) = analytic_power(T, n, δ, σs, α, one_sided) - p
     return fzero(gap, 2.0, 1.0e12)
 end
 
-@doc """
+"""
 Compute the type 1 error rate of a test. Users must specify:
 
 * `ns`: Per-group sample size(s)
@@ -93,20 +93,20 @@ Compute the type 1 error rate of a test. Users must specify:
 * `σs`: Per-group standard deviations
 * `α`: Significance level (defaults to 0.05)
 * `one_sided`: Is the test one-sided? (defaults to false)
-""" ->
-function type_1{T}(
+"""
+function type_1(
     ::Type{T},
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     α::Real = 0.05,
     one_sided::Bool = false,
-)
+) where {T}
     check_args(ns, δ, σs, 0.8, α)
     return α
 end
 
-@doc """
+"""
 Compute the type 2 error rate of a test. Users must specify:
 
 * `ns`: Per-group sample size(s)
@@ -114,20 +114,20 @@ Compute the type 2 error rate of a test. Users must specify:
 * `σs`: Per-group standard deviations
 * `α`: Significance level (defaults to 0.05)
 * `one_sided`: Is the test one-sided? (defaults to false)
-""" ->
-function type_2{T}(
+"""
+function type_2(
     ::Type{T},
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     α::Real = 0.05,
     one_sided::Bool = false,
-)
+) where {T}
     check_args(ns, δ, σs, 0.8, α)
     return 1 - power(T, ns, δ, σs, α, one_sided)
 end
 
-@doc """
+"""
 Compute the type S error rate of a test. Users must specify:
 
 * `ns`: Per-group sample size(s)
@@ -135,14 +135,14 @@ Compute the type S error rate of a test. Users must specify:
 * `σs`: Per-group standard deviations
 * `α`: Significance level (defaults to 0.05)
 * `one_sided`: Is the test one-sided? (defaults to false)
-""" ->
-function type_s{T}(
+"""
+function type_s(
     ::Type{T},
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     α::Real = 0.05,
-)
+) where {T}
     check_args(ns, δ, σs, 0.8, α)
     null, alt = hypotheses(T, ns, δ, σs)
     c_l, c_r = quantile(null, α / 2), cquantile(null, α / 2)
@@ -150,7 +150,7 @@ function type_s{T}(
     return p_l / (p_l + p_r)
 end
 
-@doc """
+"""
 Compute the type M error rate of a test. Users must specify:
 
 * `ns`: Per-group sample size(s)
@@ -158,15 +158,15 @@ Compute the type M error rate of a test. Users must specify:
 * `σs`: Per-group standard deviations
 * `α`: Significance level (defaults to 0.05)
 * `one_sided`: Is the test one-sided? (defaults to false)
-""" ->
-function type_m{T}(
+"""
+function type_m(
     ::Type{T},
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     α::Real = 0.05,
     one_sided::Bool = false,
-)
+) where {T}
     check_args(ns, δ, σs, 0.8, α)
     null, alt = hypotheses(T, ns, δ, σs)
     if one_sided
@@ -184,7 +184,7 @@ function type_m{T}(
     end
 end
 
-@doc """
+"""
 Compute the average exaggeration factor of a test. Users must specify:
 
 * `ns`: Per-group sample size(s)
@@ -192,17 +192,17 @@ Compute the average exaggeration factor of a test. Users must specify:
 * `σs`: Per-group standard deviations
 * `α`: Significance level (defaults to 0.05)
 * `one_sided`: Is the test one-sided? (defaults to false)
-""" ->
-function exaggeration_factor{T}(
+"""
+function exaggeration_factor(
     ::Type{T},
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     α::Real = 0.05,
     one_sided::Bool = false,
     bounds::Real = 1e-8,
     tol::Real = 1e-8,
-)
+) where {T}
     check_args(ns, δ, σs, 0.8, α)
     null, alt = hypotheses(T, ns, δ, σs)
     if one_sided

--- a/src/t_test.jl
+++ b/src/t_test.jl
@@ -1,10 +1,10 @@
-@doc """
+"""
 Determine the null and alternate hypotheses under t-tests given:
 
 * `ns`: Per-group sample size(s)
 * `δ`: Deviation from the null
 * `σs`: Per-group standard deviations
-""" ->
+"""
 function hypotheses(::Type{OneSampleTTest}, n::Real, δ::Real, σ::Real)
     df = n - 1
     ncp = sqrt(n) * δ / σ
@@ -13,13 +13,13 @@ function hypotheses(::Type{OneSampleTTest}, n::Real, δ::Real, σ::Real)
     return null, alt
 end
 
-@doc """
+"""
 Determine the null and alternate hypotheses under t-tests given:
 
 * `ns`: Per-group sample size(s)
 * `δ`: Deviation from the null
 * `σs`: Per-group standard deviations
-""" ->
+"""
 function hypotheses(::Type{EqualVarianceTTest}, n::Real, δ::Real, σ::Real)
     df = 2 * n - 2
     ncp = sqrt(n / 2) * δ / σ
@@ -28,13 +28,13 @@ function hypotheses(::Type{EqualVarianceTTest}, n::Real, δ::Real, σ::Real)
     return null, alt
 end
 
-@doc """
+"""
 Determine the null and alternate hypotheses under t-tests given:
 
 * `ns`: Per-group sample size(s)
 * `δ`: Deviation from the null
 * `σs`: Per-group standard deviations
-""" ->
+"""
 function hypotheses(::Type{EqualVarianceTTest}, ns::Tuple, δ::Real, σ::Real)
     n1, n2 = ns[1], ns[2]
     df = n1 + n2 - 2

--- a/src/t_test.jl
+++ b/src/t_test.jl
@@ -47,4 +47,4 @@ end
 # @doc """
 # Determine the values of t that lead to overestimates of the magnitude of δ.
 # """ ->
-thresholds(alt::NoncentralT) = -alt.ncp, alt.ncp
+thresholds(alt::NoncentralT) = -alt.λ, alt.λ

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-@doc """
+"""
 Check that user-facing function arguments satisfy assumptions made in code:
 
 * Per-group sample size is at least 2
@@ -6,11 +6,11 @@ Check that user-facing function arguments satisfy assumptions made in code:
 * The variance in each group is strictly positive
 * The power is between 0 and 1
 * The significance level is between 0 and 1
-""" ->
+"""
 function check_args(
-    ns::Union(Real, Tuple),
+    ns::Union{Real, Tuple},
     δ::Real,
-    σs::Union(Real, Tuple),
+    σs::Union{Real, Tuple},
     p::Real,
     α::Real,
 )

--- a/src/z_test.jl
+++ b/src/z_test.jl
@@ -1,10 +1,10 @@
-@doc """
+"""
 Determine the null and alternate hypotheses under z-tests given:
 
 * `ns`: Per-group sample size(s)
 * `δ`: Deviation from the null
 * `σs`: Per-group standard deviations
-""" ->
+"""
 function hypotheses(::Type{OneSampleZTest}, n::Real, δ::Real, σ::Real)
     se = sqrt(1 / n) * σ
     null = Normal(0, se)
@@ -12,13 +12,13 @@ function hypotheses(::Type{OneSampleZTest}, n::Real, δ::Real, σ::Real)
     return null, alt
 end
 
-@doc """
+"""
 Determine the null and alternate hypotheses under t-tests given:
 
 * `ns`: Per-group sample size(s)
 * `δ`: Deviation from the null
 * `σs`: Per-group standard deviations
-""" ->
+"""
 function hypotheses(::Type{EqualVarianceZTest}, n::Real, δ::Real, σ::Real)
     se = sqrt(2 / n) * σ
     null = Normal(0, se)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ fatalerrors = length(ARGS) > 0 && ARGS[1] == "-f"
 quiet = length(ARGS) > 0 && ARGS[1] == "-q"
 anyerrors = false
 
-using Base.Test
+using Test
 using PowerAnalysis
 
 my_tests = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,36 +2,9 @@
 # Correctness Tests
 #
 
-fatalerrors = length(ARGS) > 0 && ARGS[1] == "-f"
-quiet = length(ARGS) > 0 && ARGS[1] == "-q"
-anyerrors = false
-
 using Test
 using PowerAnalysis
+using HypothesisTests
 
-my_tests = [
-    "t_test.jl",
-    "z_test.jl",
-]
-
-println("Running tests:")
-
-for my_test in my_tests
-    try
-        include(my_test)
-        println("\t\033[1m\033[32mPASSED\033[0m: $(my_test)")
-    catch e
-        anyerrors = true
-        println("\t\033[1m\033[31mFAILED\033[0m: $(my_test)")
-        if fatalerrors
-            rethrow(e)
-        elseif !quiet
-            showerror(STDOUT, e, backtrace())
-            println()
-        end
-    end
-end
-
-if anyerrors
-    throw("Tests failed")
-end
+include("t_test.jl")
+include("z_test.jl")

--- a/test/t_test.jl
+++ b/test/t_test.jl
@@ -1,7 +1,4 @@
-module TestTTest
-    using Base.Test
-    using PowerAnalysis
-    using HypothesisTests
+@testset "TestTTest" begin
 
     # OneSampleTTest tests
     # Loop over n, d, p, s and one_sided

--- a/test/z_test.jl
+++ b/test/z_test.jl
@@ -1,7 +1,4 @@
-module TestZTest
-    using Base.Test
-    using PowerAnalysis
-    using HypothesisTests
+@testset "TestZTest" begin
 
     # OneSampleZTest tests
     # Loop over n, d, p, s, two_sided values


### PR DESCRIPTION
This is mostly straightforward. I haven't fixed up the tests yet, but the only thing not working from functions in the README is in this method: `thresholds(alt::NoncentralT) = -alt.ncp, alt.ncp`, where `NoncentralT` distribution no longer has `ncp`

```
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.0-DEV.1668 (2020-12-04)
 _/ |\__'_|_|_|\__'_|  |  Commit 0253ebf147 (7 days old master)
|__/                   |

julia> using PowerAnalysis, HypothesisTests

julia> n = 100
100

julia> δ = 0.01
0.01

julia> σs = 1.0
1.0

julia> p = 0.8
0.8

julia> α = 0.05
0.05

julia> power(EqualVarianceTTest, n, δ, σs, α)
0.05056741592646641

julia> effect_size(EqualVarianceTTest, n, p, α)
0.39813813756823213

julia> sample_size(EqualVarianceTTest, δ, σs, p, α)
156978.1705208713

julia> type_1(EqualVarianceTTest, n, δ, σs, α)
0.05

julia> type_2(EqualVarianceTTest, n, δ, σs, α)
0.9494325840735336

julia> type_s(EqualVarianceTTest, n, δ, σs, α)
0.41847831065271157

julia> type_m(EqualVarianceTTest, n, δ, σs, α)
ERROR: type NoncentralT has no field ncp
Stacktrace:
 [1] getproperty(x::Distributions.NoncentralT{Float64}, f::Symbol)
   @ Base ./Base.jl:33
 [2] thresholds(alt::Distributions.NoncentralT{Float64})
   @ PowerAnalysis ~/Repos/PowerAnalysis.jl/src/t_test.jl:50
 [3] type_m(::Type{EqualVarianceTTest}, ns::Int64, δ::Float64, σs::Float64, α::Float64, one_sided::Bool)
   @ PowerAnalysis ~/Repos/PowerAnalysis.jl/src/generics.jl:180
 [4] type_m(::Type{EqualVarianceTTest}, ns::Int64, δ::Float64, σs::Float64, α::Float64)
   @ PowerAnalysis ~/Repos/PowerAnalysis.jl/src/generics.jl:170
 [5] top-level scope
   @ REPL[14]:1

julia> exaggeration_factor(EqualVarianceTTest, n, δ, σs, α)
ERROR: type NoncentralT has no field ncp
```

The type signature changed from [here](https://github.com/JuliaStats/Distributions.jl/blob/ff39d9bf764577971560e6bbfc5e8e604351e311/src/univariate/continuous/noncentralt.jl#L1-L8)

```
immutable NoncentralT <: ContinuousUnivariateDistribution
    df::Float64
    ncp::Float64
    function NoncentralT(d::Real, nc::Real)
    	d >= zero(d) && nc >= zero(nc) || error("df and ncp must be non-negative")
        new(float64(d), float64(nc))
    end
end
```

[to here](https://github.com/JuliaStats/Distributions.jl/blob/master/src/univariate/continuous/noncentralt.jl#L4-L8)

```
struct NoncentralT{T<:Real} <: ContinuousUnivariateDistribution
    ν::T
    λ::T
    NoncentralT{T}(ν::T, λ::T) where {T} = new{T}(ν, λ)
end
```

So is `ncp` just the new `λ`?

Still needs:

- [x] What's `ncp`?
- [x] fix tests syntax
- [x] Add test and docs bots

I'm happy to keep going here, though if you're not interested in holding onto ownership, maybe it could be migrated to the JuliaStats org?